### PR TITLE
through2 interface, optional transform fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,16 @@ fs.createReadStream('data.csv')
   }));
 ```
 
+Don't specify a transform fn, and let the batches be processed by another stream
+```javascript
+var through2Batch = require('through2-batch');
+
+fs.createReadStream('data.csv')
+  .pipe(csv2())
+  .pipe(through2Batch.obj())
+  .pipe(getSomeOtherStreamProcessingBatches());
+```
+
 
 Contributing
 ------------

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "through2-batch",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A stream that transforms chunks to batches form the stream",
   "main": "through2-batch.js",
   "files": [

--- a/tests.js
+++ b/tests.js
@@ -1,4 +1,5 @@
 var through2Batch = require('./through2-batch');
+var through2 = require('through2');
 var _ = require('lodash');
 var streamify = require('stream-array');
 var sinon = require('sinon');
@@ -100,6 +101,40 @@ describe("through2-batch", function() {
 
     });
 
+    describe("through2 interface", function() {
+        testTemplate = function(through2BatchTransform, done) {
+            objectsProcessed = 0
+
+            stream.pipe(through2Batch.obj(through2BatchTransform))
+                .pipe(through2.obj(lastTransformSpy = sinon.spy(function(batch, enc, next){
+                        objectsProcessed += batch.length
+                        next()
+                })))
+                .on('finish', function() {
+                    expect(lastTransformSpy.callCount).to.be.above(0);
+                    expect(objectsProcessed).to.be.equal(1000);
+                    done();
+                });
+        };
+
+        it("passes values to next stream using this.push()", function(done) {
+            transform = function(batch, enc, next){
+                this.push(batch);
+                next();
+            };
+            testTemplate(transform, done);
+        });
+
+        it("passes values to next stream using .next(null, values)", function(done) {
+            transform = function(batch, enc, next){
+                next(null, batch);
+            };
+            testTemplate(transform, done);
+
+        });
+
+    });
+
     function shouldHaveBatchedWithSize(batchSize, transform) {
         var totalProcessed = 0;
         var totalBatches = Math.ceil(objs.length / batchSize);
@@ -119,3 +154,5 @@ describe("through2-batch", function() {
         expect(totalProcessed).to.equal(objs.length);
     }
 });
+
+

--- a/tests.js
+++ b/tests.js
@@ -134,6 +134,20 @@ describe("through2-batch", function() {
         });
 
     });
+    describe("optional tranform fn", function() {
+        it("doesn't need tranform fn and can just pipe batch to next stream", function(done) {
+            var objectsProcessed = 0
+            stream.pipe(through2Batch.obj())
+                .pipe(through2.obj(function(batch, enc, next){
+                    objectsProcessed += batch.length
+                    next();
+                }))
+                .on('finish', function(){
+                  expect(objectsProcessed).to.be.equal(1000);
+                  done()
+                });
+        });
+    });
 
     function shouldHaveBatchedWithSize(batchSize, transform) {
         var totalProcessed = 0;

--- a/through2-batch.js
+++ b/through2-batch.js
@@ -6,7 +6,7 @@ module.exports = function batchThrough(options, transform, flush) {
   var batchSize;
   var lastEnc = null;
 
-  if (typeof options === 'function') {
+  if (typeof options !== 'object') {
       flush     = transform;
       transform = options;
       options   = {};
@@ -23,16 +23,18 @@ module.exports = function batchThrough(options, transform, flush) {
   function _transform(message, enc, callback) {
       var self = this;
       lastEnc = enc;
-      var callbackCalled = false;
       batched.push(message);
 
       if (batched.length < batchSize) {
           callback();
-      } else {
+      } else if (transform) {
           transform.call(this, batched, enc, function (err, data) {
               batched = [];
               callback(err, data);
           });
+      } else {
+        callback(null, batched);
+        batched = [];
       }
   }
 
@@ -54,7 +56,7 @@ module.exports = function batchThrough(options, transform, flush) {
 };
 
 module.exports.obj = function (options, transform, flush) {
-  if (typeof options === 'function') {
+  if (typeof options !== 'object') {
     flush     = transform;
     transform = options;
     options   = {};

--- a/through2-batch.js
+++ b/through2-batch.js
@@ -29,9 +29,9 @@ module.exports = function batchThrough(options, transform, flush) {
       if (batched.length < batchSize) {
           callback();
       } else {
-          transform.call(this, batched, enc, function (err) {
+          transform.call(this, batched, enc, function (err, data) {
               batched = [];
-              callback(err);
+              callback(err, data);
           });
       }
   }


### PR DESCRIPTION
I just used this package as a small utility to get things done. However, there are 2 minor things that could help me as well as many other users of this package. At the same time, the pull request does not introduce any breaking changes.

Problem1: through2-batch was designed as the last writable stream in the pipeline. The only way, you could possibly pass the batch to another stream was via `this.push(batch)` within the transform fn. This cost me actually a lot of time to figure it out.
Solutions1: you can also use the callback to pass the values to the next stream: `next(null, batch)` - like in through2

Problem2: in most cases, I believe, you just want to create a batch and process it in another stream; i.e. no transform fn si really needed
Solution2: providing transform fn to through2-batch is now optional

Note: readme updated, tests for "new" features provided