### PR TITLE
Don't call `transform` if it isn't defined.

### DIFF
--- a/through2-batch.js
+++ b/through2-batch.js
@@ -49,6 +49,7 @@ module.exports = function batchThrough(options, transform, flush) {
                   else flush.call(self, callback);
               });
           } else {
+              callback(null, batched);
               batched = [];
               flush.call(this,callback);
           }

--- a/through2-batch.js
+++ b/through2-batch.js
@@ -42,11 +42,16 @@ module.exports = function batchThrough(options, transform, flush) {
       var self = this;
 
       if (batched.length > 0) {
-          transform.call(this, batched, lastEnc, function (err) {
+          if (transform) {
+              transform.call(this, batched, lastEnc, function (err) {
+                  batched = [];
+                  if (err) callback(err);
+                  else flush.call(self, callback);
+              });
+          } else {
               batched = [];
-              if (err) callback(err);
-              else flush.call(self, callback);
-          });
+              flush.call(this,callback);
+          }
       } else {
           flush.call(this,callback);
       }


### PR DESCRIPTION
`transform` is called in `_flush`, even if the user didn't provide one.